### PR TITLE
LPS-95284 | Pages finder dropdown no longer works

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.soy
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.soy
@@ -34,7 +34,7 @@
 		</button>
 
 		{if $_showFinder}
-			<div class="fade modal show">
+			<div class="d-block fade modal show">
 				<div
 					class="modal-dialog modal-dialog-sm mt-5 position-relative"
 					ref="dialog"


### PR DESCRIPTION
Hi @p2kmgcl ,

This is a quick fix for a severe regression. The proper solution will be to replace custom modal implementation with ClayModal, https://issues.liferay.com/browse/LPS-95325

Please review the code.

Thank you!