### PR TITLE
LPS-105667 - set overflow to visible to account for dropdown menus

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -72,7 +72,7 @@
 .has-control-menu.has-edit-mode-menu #wrapper {
 	height: calc(100vh - #{$controlMenuHeight + $managementBarHeight});
 	margin-top: $controlMenuHeight + $managementBarHeight;
-	overflow-y: auto;
+	overflow: visible;
 
 	@media (min-width: 768px) {
 		height: calc(


### PR DESCRIPTION
Hey @p2kmgcl, I'm not totally sure who i responsible for this code, but I saw your name in the commit history.

I was looking into https://issues.liferay.com/browse/LPS-105667 and came across an issue where our alignment library doesn't work properly for our case. I actually think the library is accurate in accounting for overflow, but I think our css might be wrong on our end. Can you verify this and see if this causes other issues? I tested it manually, but since I am unfamiliar with the project, I couldn't be sure.

I also opened an issue with the align library in case if might be their issue. https://github.com/yiminghe/dom-align/issues/50

Let me know what you think.