### PR TITLE
LPS-109991 updating fragments configuration

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateFragmentConfiguration.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateFragmentConfiguration.js
@@ -28,6 +28,7 @@ export default function updateFragmentConfiguration({
 		...editableValues,
 		[FREEMARKER_FRAGMENT_ENTRY_PROCESSOR]: segmentsExperienceId
 			? {
+					...editableValues[FREEMARKER_FRAGMENT_ENTRY_PROCESSOR],
 					[segmentsExperienceId]: configurationValues,
 			  }
 			: configurationValues,


### PR DESCRIPTION
Every configuration update on fragments was overwriting all previous values. This starting happening at this commit: 253e7dbbc1ed3db5d4fbd219e80e1885c91263b4

I hope what I'm sending makes sense.

Aside from that. The fragment in the editor is not ~updating~ previewing correctly when an experience is involved. I'd like to tackle that, but I cannot get my head around it. Some guidance would be appreciated.

Thank!!

CC// @dgarciasarai