### PR TITLE
LPS-112643 Miller Columns don't use all the available space

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/css/miller_columns/MillerColumns.scss
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/css/miller_columns/MillerColumns.scss
@@ -21,7 +21,7 @@
 	}
 
 	@include media-breakpoint-up(md) {
-		height: calc(100vh - 384px);
+		height: calc(100vh - 284px);
 		min-height: 10rem;
 		overflow-y: scroll;
 	}


### PR DESCRIPTION
Hi @p2kmgcl ,

After talking to @marcoscv-work he told me we are changing the general grid so it's easier to do this kind of calculations, but this one haven't been modified yet. I'm mentioning him, so this can be added to the epic where they are carrying out this task.

In the meanwhile, I'm updating the value so we are not wasting space at the bottom of the page. Those 284px are coming from the space we need for:
- Control Menu
- NavBar
- Management Bar
- Breadcrumbs
- Bottom space according to Lexicon Pattern (PTR-1655)

Thanks.

Regards.