### PR TITLE
LPS-131995 WIP

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
@@ -174,7 +174,7 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 
 		sb.append(fragmentIdSB.toString());
 
-		sb.append("\" >");
+		sb.append("\" style=\"height: 100%\" >");
 		sb.append(html);
 		sb.append("</div>");
 

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/responsive/ResponsiveLayoutStructureUtil.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/responsive/ResponsiveLayoutStructureUtil.java
@@ -80,9 +80,11 @@ public class ResponsiveLayoutStructureUtil {
 		}
 
 		if ((rowStyledLayoutStructureItem != null) &&
-			Objects.equals(
+			(Objects.equals(
 				rowStyledLayoutStructureItem.getVerticalAlignment(),
-				"middle")) {
+				"middle") || Objects.equals(
+				rowStyledLayoutStructureItem.getVerticalAlignment(),
+				"stretch"))) {
 
 			sb.append("d-flex flex-column ");
 		}
@@ -328,6 +330,9 @@ public class ResponsiveLayoutStructureUtil {
 		}
 		else if (Objects.equals(verticalAlignment, "middle")) {
 			return "center";
+		}
+		else if (Objects.equals(verticalAlignment, "stretch")) {
+			return "stretch";
 		}
 
 		return "start";

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Layout.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Layout.scss
@@ -114,19 +114,37 @@ $dashedBorderWidth: 2px;
 	}
 
 	&__row.align-bottom,
-	&__row.align-middle {
-		.page-editor__col .page-editor__col__border {
+	&__row.align-middle,
+	&__row.align-items-stretch {
+		> .page-editor__col > .page-editor__col__border {
 			display: flex;
 			flex-direction: column;
 		}
 	}
 
-	&__row.align-middle .page-editor__col .page-editor__col__border {
+	&__row.align-middle > .page-editor__col > .page-editor__col__border {
 		justify-content: center;
 	}
 
-	&__row.align-bottom .page-editor__col .page-editor__col__border {
+	&__row.align-bottom > .page-editor__col > .page-editor__col__border {
 		justify-content: flex-end;
+	}
+
+	&__row.align-items-stretch > .page-editor__col > .page-editor__col__border {
+		justify-content: stretch;
+
+		> .page-editor__topper {
+			flex-grow: 1;
+
+			> .page-editor__topper__content
+				> .page-editor__fragment-content-interactions-filter {
+				height: 100%;
+
+				> .page-editor__fragment-content > div {
+					height: 100%;
+				}
+			}
+		}
 	}
 
 	&__collection-item {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContentInteractionsFilter.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContentInteractionsFilter.js
@@ -316,7 +316,14 @@ function FragmentContentInteractionsFilter({
 		props.onMouseOverCapture = hoverEditable;
 	}
 
-	return <div {...props}>{children}</div>;
+	return (
+		<div
+			className="page-editor__fragment-content-interactions-filter"
+			{...props}
+		>
+			{children}
+		</div>
+	);
 }
 
 FragmentContentInteractionsFilter.propTypes = {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/RowWithControls.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/RowWithControls.js
@@ -65,6 +65,7 @@ const RowWithControls = React.forwardRef(({children, item}, ref) => {
 			<Row
 				className={classNames({
 					'align-bottom': verticalAlignment === 'bottom',
+					'align-items-stretch': verticalAlignment === 'stretch',
 					'align-middle': verticalAlignment === 'middle',
 					empty:
 						isSomeRowEmpty(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowStylesPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowStylesPanel.js
@@ -52,6 +52,7 @@ const VERTICAL_ALIGNMENT_OPTIONS = [
 	{label: Liferay.Language.get('top'), value: 'top'},
 	{label: Liferay.Language.get('middle'), value: 'middle'},
 	{label: Liferay.Language.get('bottom'), value: 'bottom'},
+	{label: Liferay.Language.get('stretch'), value: 'stretch'},
 ];
 
 const ROW_STYLE_IDENTIFIERS = {


### PR DESCRIPTION
This is a work in progress for https://issues.liferay.com/browse/LPS-131995, which might be actually hard to solve. It looks like this is the kind of situation where having (slightly) different markup between edit and view modes can cause a lot of problems. As a summary:

Edit mode:
```html
<div class="topper">
  <div class="topper-content">
    <div class="fragment-content">
      <div class="fragment [COMMON_STYLES]">...</div>
    </div>
  </div>
</div>
```

View mode:
```html
<div class="fragment [COMMON_STYLES]">...</div>
```

In order to make "stretch" work, we need to apply a 100% height to all items until we reach our "fragment" node. In order to do that, we have three options:
1. (Ideal) Adding a `flex-grow: 1` to the fragment div. This is the perfect solution, but it is not very intuitive for users, as their "height" common style might be ignored.
1. Forcing users to specify "height: 100%" in common styles manually. The problem here is that toppers will expand even if users haven't set this option, so edit and view modes will look different (not acceptable).
1. Setting 100% as a default value of height common style. This might cause unexpected issues with users, who might wonder why their fragments have this height by default. Moreover this is not the same than setting flex-grow, and might cause different results with multiple fragments.